### PR TITLE
Added: Additional discriminators to caching setup. (crate-name, featu…

### DIFF
--- a/.github/workflows/test-build-workflow.yml
+++ b/.github/workflows/test-build-workflow.yml
@@ -303,6 +303,8 @@ jobs:
           size-optimized-std: true
 
   # Can build a project in a workspace.
+  # It's important caching works for both projects here; so check logs even
+  # if this passes.
   test-workspace-build:
     runs-on: ubuntu-latest
     steps:
@@ -312,13 +314,23 @@ jobs:
           repository: Sewer56/dxt-lossless-transform
           ref: d47afd9a7c2fa71495b6d942853b0fe41f258e26
 
-      - name: Test Workspace Build
+      - name: Test Workspace Build (CLI)
         uses: Reloaded-Project/devops-rust-lightweight-binary@v1-test
         with:
           rust-project-path: projects/dxt-lossless-transform-cli
           workspace-path: "."
           crate-name: dxt-lossless-transform-cli
           target: x86_64-unknown-linux-gnu
+          upload-artifacts: true
+
+      - name: Test Workspace Build (API)
+        uses: Reloaded-Project/devops-rust-lightweight-binary@v1-test
+        with:
+          rust-project-path: projects/dxt-lossless-transform-api
+          workspace-path: "."
+          crate-name: dxt-lossless-transform-api
+          target: x86_64-unknown-linux-gnu
+          features: "c-exports"
           upload-artifacts: true
 
   test-artifact-upload:

--- a/.github/workflows/test-build-workflow.yml
+++ b/.github/workflows/test-build-workflow.yml
@@ -314,15 +314,6 @@ jobs:
           repository: Sewer56/dxt-lossless-transform
           ref: d47afd9a7c2fa71495b6d942853b0fe41f258e26
 
-      - name: Test Workspace Build (CLI)
-        uses: Reloaded-Project/devops-rust-lightweight-binary@v1-test
-        with:
-          rust-project-path: projects/dxt-lossless-transform-cli
-          workspace-path: "."
-          crate-name: dxt-lossless-transform-cli
-          target: x86_64-unknown-linux-gnu
-          upload-artifacts: true
-
       - name: Test Workspace Build (API)
         uses: Reloaded-Project/devops-rust-lightweight-binary@v1-test
         with:
@@ -330,7 +321,24 @@ jobs:
           workspace-path: "."
           crate-name: dxt-lossless-transform-api
           target: x86_64-unknown-linux-gnu
-          features: "c-exports"
+          upload-artifacts: true
+
+  test-workspace-build-2:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Test Repository
+        uses: actions/checkout@v4
+        with:
+          repository: Sewer56/dxt-lossless-transform
+          ref: d47afd9a7c2fa71495b6d942853b0fe41f258e26
+
+      - name: Test Workspace Build (CLI)
+        uses: Reloaded-Project/devops-rust-lightweight-binary@v1-test
+        with:
+          rust-project-path: projects/dxt-lossless-transform-cli
+          workspace-path: "."
+          crate-name: dxt-lossless-transform-cli
+          target: x86_64-unknown-linux-gnu
           upload-artifacts: true
 
   test-artifact-upload:

--- a/README.MD
+++ b/README.MD
@@ -126,6 +126,7 @@ To use this action in your own repository:
 | `pgo-benchmark-name`         | No       | `'my_benchmark'` | Benchmark name to use with PGO.                                                        |
 | `use-cross`                  | No       | `false`          | Use cross-rs for building. If false, use cargo.                                        |
 | `additional-rustflags`       | No       | `''`             | Additional RUSTFLAGS to pass to the Rust compiler                                      |
+| `use-cache`                  | No       | `true`           | Enable or disable the build cache using `Swatinem/rust-cache`.                         |
 | `upload-artifacts`           | No       | `true`           | Upload the built artifacts as a GitHub Actions artifact                                |
 | `abort-on-panic`             | No       | `true`           | Abort immediately on panic. If false, the default panic handler is used.               |
 | `build-library`              | No       | `false`          | Build a library instead of a binary.                                                   |
@@ -232,6 +233,68 @@ Find more examples in [the tests](./.github/workflows/test-rust-build-c-library-
     crate-name: my-crate
     target: x86_64-unknown-linux-gnu
     additional-rustflags: -C opt-level=3
+```
+
+### Building Multiple Projects
+
+#### Serial Builds (Single Job)
+
+If you are building multiple projects, for example multiple projects in a single workspace, 
+build them in a single job:
+
+```yaml
+- name: Build API Crate
+  uses: Reloaded-Project/devops-rust-lightweight-binary@v1
+  with:
+    rust-project-path: projects/api-crate
+    crate-name: api-crate
+    target: x86_64-unknown-linux-gnu
+    use-cache: true  # Only first build enables cache
+    upload-artifacts: true
+
+- name: Build CLI Crate
+  uses: Reloaded-Project/devops-rust-lightweight-binary@v1
+  with:
+    rust-project-path: projects/cli-crate
+    crate-name: cli-crate
+    target: x86_64-unknown-linux-gnu
+    use-cache: false  # Subsequent builds disable cache
+    upload-artifacts: true
+```
+
+The cache is restored in `Build API Crate` and saved after completion of `Build CLI Crate`.
+So you should only set `use-cache` on the first project.
+
+#### Parallel Builds
+
+If you are building multiple projects with either different compiler settings, features, or targets, 
+build them in separate jobs:
+
+```yaml
+jobs:
+  build-api:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: Reloaded-Project/devops-rust-lightweight-binary@v1
+        with:
+          rust-project-path: projects/api-crate
+          crate-name: api-crate
+          target: x86_64-unknown-linux-gnu
+          use-cache: true # this is the default
+          upload-artifacts: true
+
+  build-cli:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: Reloaded-Project/devops-rust-lightweight-binary@v1
+        with:
+          rust-project-path: projects/cli-crate
+          crate-name: cli-crate
+          target: x86_64-unknown-linux-gnu
+          use-cache: true # this is the default
+          upload-artifacts: true
 ```
 
 ## Accessing the Built Artifacts

--- a/action.yml
+++ b/action.yml
@@ -111,6 +111,12 @@ runs:
           SAFE_FEATURES="no-features"
         fi
         
+        # Sanitize additional-std-features string to be filesystem safe
+        SAFE_ADDITIONAL_STD_FEATURES=$(echo "${{ inputs.additional-std-features }}" | tr -dc '[:alnum:],_-' | tr ',' '-')
+        if [ -z "$SAFE_ADDITIONAL_STD_FEATURES" ]; then
+          SAFE_ADDITIONAL_STD_FEATURES="no-std-features"
+        fi
+
         # Sanitize workspace path - convert '.' to empty string
         WORKSPACE_PATH=$(echo "${{ env.WORKSPACE_PATH }}" | sed 's/^\.$//') 
 
@@ -127,11 +133,12 @@ runs:
         mkdir -p "$ARTIFACT_OUT_DIR"
         echo "ARTIFACT_OUT_DIR=${ARTIFACT_OUT_DIR}" >> $GITHUB_ENV
         echo "SAFE_FEATURES=${SAFE_FEATURES}" >> $GITHUB_ENV
+        echo "SAFE_ADDITIONAL_STD_FEATURES=${SAFE_ADDITIONAL_STD_FEATURES}" >> $GITHUB_ENV
 
     - name: Setup Rust Caching
       uses: Swatinem/rust-cache@v2
       with:
-        key: workspace-${{ env.WORKSPACE_PATH }}-${{ inputs.crate-name }}-${{ inputs.target }}-${{ env.SAFE_FEATURES }}-${{ inputs.additional-std-features }}
+        key: build-${{ env.WORKSPACE_PATH }}-${{ inputs.crate-name }}-${{ inputs.target }}-${{ env.SAFE_FEATURES }}-${{ env.SAFE_ADDITIONAL_STD_FEATURES }}-${{ inputs.no-default-features }}-${{ inputs.build-library }}-${{ inputs.crate-types }}-${{ inputs.use-cross }}
         cache-on-failure: true
         cache-all-crates: true
         workspaces: |

--- a/action.yml
+++ b/action.yml
@@ -133,6 +133,7 @@ runs:
       with:
         key: workspace-${{ env.WORKSPACE_PATH }}-${{ inputs.crate-name }}-${{ inputs.target }}-${{ env.SAFE_FEATURES }}-${{ inputs.additional-std-features }}
         cache-on-failure: true
+        cache-all-crates: true
         workspaces: |
           ${{ env.WORKSPACE_PATH }} -> target
 

--- a/action.yml
+++ b/action.yml
@@ -130,7 +130,7 @@ runs:
     - name: Setup Rust Caching
       uses: Swatinem/rust-cache@v2
       with:
-        key: workspace-${{ env.WORKSPACE_PATH }}+${{ inputs.target }}
+        key: workspace-${{ env.WORKSPACE_PATH }}-${{ inputs.crate-name }}-${{ inputs.target }}-${{ inputs.features }}-${{ inputs.additional-std-features }}
         cache-on-failure: true
         workspaces: |
           ${{ env.WORKSPACE_PATH }} -> target

--- a/action.yml
+++ b/action.yml
@@ -82,6 +82,10 @@ inputs:
     description: 'Path to the workspace root. Defaults to rust-project-path if not specified.'
     required: false
     default: ''
+  use-cache:
+    description: 'Enable or disable the build cache using Swatinem/rust-cache.'
+    required: false
+    default: "true"
 
 runs:
   using: 'composite'
@@ -136,6 +140,7 @@ runs:
         echo "SAFE_ADDITIONAL_STD_FEATURES=${SAFE_ADDITIONAL_STD_FEATURES}" >> $GITHUB_ENV
 
     - name: Setup Rust Caching
+      if: inputs.use-cache == 'true'
       uses: Swatinem/rust-cache@v2
       with:
         key: build-${{ env.WORKSPACE_PATH }}-${{ inputs.crate-name }}-${{ inputs.target }}-${{ env.SAFE_FEATURES }}-${{ env.SAFE_ADDITIONAL_STD_FEATURES }}-${{ inputs.no-default-features }}-${{ inputs.build-library }}-${{ inputs.crate-types }}-${{ inputs.use-cross }}

--- a/action.yml
+++ b/action.yml
@@ -126,11 +126,12 @@ runs:
         ARTIFACT_OUT_DIR="${BASE_PATH}artifact-out/${{ inputs.crate-name }}/${{ inputs.target }}/${SAFE_FEATURES}"
         mkdir -p "$ARTIFACT_OUT_DIR"
         echo "ARTIFACT_OUT_DIR=${ARTIFACT_OUT_DIR}" >> $GITHUB_ENV
+        echo "SAFE_FEATURES=${SAFE_FEATURES}" >> $GITHUB_ENV
 
     - name: Setup Rust Caching
       uses: Swatinem/rust-cache@v2
       with:
-        key: workspace-${{ env.WORKSPACE_PATH }}-${{ inputs.crate-name }}-${{ inputs.target }}-${{ inputs.features }}-${{ inputs.additional-std-features }}
+        key: workspace-${{ env.WORKSPACE_PATH }}-${{ inputs.crate-name }}-${{ inputs.target }}-${{ env.SAFE_FEATURES }}-${{ inputs.additional-std-features }}
         cache-on-failure: true
         workspaces: |
           ${{ env.WORKSPACE_PATH }} -> target


### PR DESCRIPTION
…res, std-features)

I found that in some projects, building multiple projects led to cache being invalidated; because it would get overwritten between builds.