### PR TITLE
Improve: Standardize test workflow triggers and remove tag-based push events

### DIFF
--- a/.github/workflows/test-build-workflow.yml
+++ b/.github/workflows/test-build-workflow.yml
@@ -4,13 +4,6 @@ on:
   schedule:
     - cron: "0 0 * * *" # Run daily at midnight
   workflow_dispatch:
-  push:
-    tags:
-      - "v1"
-      - "v1-test"
-    paths:
-      - "action.yml"
-      - ".github/workflows/test-build-workflow.yml"
   pull_request:
     branches: [v1-master]
     paths:

--- a/.github/workflows/test-friendly-names.yml
+++ b/.github/workflows/test-friendly-names.yml
@@ -1,15 +1,9 @@
 name: Test Friendly Target Names (Enabled)
 
 on:
+  schedule:
+    - cron: "0 0 * * *" # Run daily at midnight
   workflow_dispatch:
-  push:
-    tags:
-      - "v1"
-      - "v1-test"
-    paths:
-      - "action.yml"
-      - "scripts/get-friendly-target-name.sh"
-      - ".github/workflows/test-friendly-names.yml"
   pull_request:
     branches: [v1-master]
     paths:

--- a/.github/workflows/test-symbols-bundled.yml
+++ b/.github/workflows/test-symbols-bundled.yml
@@ -4,13 +4,6 @@ on:
   schedule:
     - cron: "0 0 * * *" # Run daily at midnight
   workflow_dispatch:
-  push:
-    tags:
-      - "v1"
-      - "v1-test"
-    paths:
-      - "action.yml"
-      - ".github/workflows/test-symbols-bundled.yml"
   pull_request:
     branches: [v1-master]
     paths:

--- a/.github/workflows/test-symbols-separate.yml
+++ b/.github/workflows/test-symbols-separate.yml
@@ -4,13 +4,6 @@ on:
   schedule:
     - cron: "0 0 * * *" # Run daily at midnight
   workflow_dispatch:
-  push:
-    tags:
-      - "v1"
-      - "v1-test"
-    paths:
-      - "action.yml"
-      - ".github/workflows/test-symbols-separate.yml"
   pull_request:
     branches: [v1-master]
     paths:

--- a/.github/workflows/test-unfriendly-names.yml
+++ b/.github/workflows/test-unfriendly-names.yml
@@ -1,15 +1,9 @@
 name: Test Friendly Target Names (Disabled)
 
 on:
+  schedule:
+    - cron: "0 0 * * *" # Run daily at midnight
   workflow_dispatch:
-  push:
-    tags:
-      - "v1"
-      - "v1-test"
-    paths:
-      - "action.yml"
-      - "scripts/get-friendly-target-name.sh"
-      - ".github/workflows/test-unfriendly-names.yml"
   pull_request:
     branches: [v1-master]
     paths:


### PR DESCRIPTION
- Remove push trigger on v1/v1-test tags from all test workflows
- Add daily schedule (midnight UTC) to friendly/unfriendly name tests
- Ensure consistent trigger configuration across all 5 test workflows
- Workflows now trigger on: schedule, workflow_dispatch, and pull_request