### PR TITLE
Add packages input parameter

### DIFF
--- a/README.MD
+++ b/README.MD
@@ -138,6 +138,9 @@ These parameters are only used when `run-tests-and-coverage` is enabled and are 
 | `additional-tarpaulin-args`  | No       | `''`                 | Additional arguments passed directly to the cargo tarpaulin command.                                  |
 | `codecov-flags`              | No       | `'unittests'`        | Flags to pass to Codecov for organizing coverage reports.                                             |
 | `codecov-name`               | No       | `'codecov-umbrella'` | Custom defined name for the coverage upload.                                                          |
+| `packages`                   | No       | `''`                 | Multi-line list of package names to test (one per line). If empty, tests all packages in workspace.   |
+
+**Note:** The `packages` parameter is passed through to the test action and does not affect which binary is built.
 
 **Note:** The following parameters are used by both this action AND passed through to the test action: `target`, `features`, `no-default-features`, `use-cross`.
 

--- a/action.yml
+++ b/action.yml
@@ -165,6 +165,10 @@ inputs:
     description: "Additional arguments to pass to the cargo tarpaulin command"
     required: false
     default: ""
+  packages:
+    description: "Packages to test (multi-line list). Passed through to devops-rust-test-and-coverage. Selects packages for testing; does not influence the build."
+    required: false
+    default: ""
   codecov-flags:
     description: "Flags to pass to Codecov for organizing coverage reports"
     required: false
@@ -555,3 +559,4 @@ runs:
         codecov-flags: ${{ inputs.codecov-flags }}
         codecov-name: ${{ inputs.codecov-name }}
         additional-tarpaulin-args: ${{ inputs.additional-tarpaulin-args }}
+        packages: ${{ inputs.packages }}


### PR DESCRIPTION
## Summary

Adds support for the new `packages` input parameter introduced in [devops-rust-test-and-coverage](https://github.com/Reloaded-Project/devops-rust-test-and-coverage).

## Changes

- Added `packages` input parameter to `action.yml`
- Passed `packages` through to the `devops-rust-test-and-coverage` action
- Documented the parameter in `README.MD`
- Added clarifying note that the parameter does not affect build output

## Usage

```yaml
- uses: Reloaded-Project/devops-rust-lightweight-binary@v1
  with:
    target: x86_64-unknown-linux-gnu
    run-tests-and-coverage: true
    packages: |
      package-a
      package-b
```

## Benefits

- Users can now selectively test specific packages in multi-package workspaces
- Consistent with upstream `devops-rust-test-and-coverage` action API
- Clear documentation prevents confusion about build vs test scope